### PR TITLE
Thermal foundation casting fix

### DIFF
--- a/src/main/java/com/mrthomas20121/tinkers_reforged/Module/ModuleBase.java
+++ b/src/main/java/com/mrthomas20121/tinkers_reforged/Module/ModuleBase.java
@@ -2,6 +2,7 @@ package com.mrthomas20121.tinkers_reforged.Module;
 
 import com.mrthomas20121.tinkers_reforged.TinkersReforged;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
@@ -36,6 +37,9 @@ public abstract class ModuleBase {
             TinkerRegistry.registerTableCasting(OreDictionary.getOres("ingot"+ore).get(0), castIngot, fluid, Material.VALUE_Ingot);
             TinkerRegistry.registerTableCasting(OreDictionary.getOres("plate"+ore).get(0), castPlate, fluid, Material.VALUE_Ingot);
             TinkerRegistry.registerTableCasting(OreDictionary.getOres("gear"+ore).get(0), castGear, fluid, Material.VALUE_Ingot*4);
+            NonNullList<ItemStack> list = OreDictionary.getOres("block"+ore);
+            if (list.size()>0)
+                TinkerRegistry.registerBasinCasting(OreDictionary.getOres("block"+ore).get(0), ItemStack.EMPTY, fluid, Material.VALUE_Block);
         }
     }
 }

--- a/src/main/java/com/mrthomas20121/tinkers_reforged/Module/ModuleThermal.java
+++ b/src/main/java/com/mrthomas20121/tinkers_reforged/Module/ModuleThermal.java
@@ -133,24 +133,46 @@ public class ModuleThermal extends ModuleBase {
     }
     @Override
     public void init(FMLInitializationEvent e) {
+        if(Config.invar) {
+            Fluid fluid = FluidRegistry.getFluid((invarOre.toLowerCase()));
+            invar.registerInitFluid(fluid, invarOre);
+            this.registerDefaultMelting(invarOre, fluid, true);
+            invar.setCastable(true).setCraftable(false);
+        }
+        if(Config.aluminum) {
+            Fluid fluid = FluidRegistry.getFluid((aluminumOre.toLowerCase()));
+            aluminum.registerInitFluid(fluid, aluminumOre);
+            this.registerDefaultMelting(aluminumOre, fluid, true);
+            aluminum.setCastable(true).setCraftable(false);
+        }
         if(Config.enderium) {
-            enderium.registerInitFluid(FluidRegistry.getFluid((enderiumOre.toLowerCase())), enderiumOre);
+            Fluid fluid = FluidRegistry.getFluid((enderiumOre.toLowerCase()));
+            enderium.registerInitFluid(fluid, enderiumOre);
+            this.registerDefaultMelting(enderiumOre, fluid, true);
             enderium.setCastable(true).setCraftable(false);
         }
         if(Config.signalum) {
-            signalum.registerInitFluid(FluidRegistry.getFluid((signalumOre.toLowerCase())), signalumOre);
+            Fluid fluid = FluidRegistry.getFluid((signalumOre.toLowerCase()));
+            signalum.registerInitFluid(fluid, signalumOre);
+            this.registerDefaultMelting(signalumOre, fluid, true);
             signalum.setCastable(true).setCraftable(false);
         }
         if(Config.lumium) {
-            lumium.registerInitFluid(FluidRegistry.getFluid((lumiumOre.toLowerCase())), lumiumOre);
+            Fluid fluid = FluidRegistry.getFluid((lumiumOre.toLowerCase()));
+            lumium.registerInitFluid(fluid, lumiumOre);
+            this.registerDefaultMelting(lumiumOre, fluid, true);
             lumium.setCastable(true).setCraftable(false);
         }
         if(Config.iridium) {
-            iridium.registerInitFluid(FluidRegistry.getFluid((iridiumOre.toLowerCase())), iridiumOre);
+            Fluid fluid = FluidRegistry.getFluid((iridiumOre.toLowerCase()));
+            iridium.registerInitFluid(fluid, iridiumOre);
+            this.registerDefaultMelting(iridiumOre, fluid, true);
             iridium.setCraftable(false).setCastable(true);
         }
         if(Config.platinum) {
-            platinum.registerInitFluid(FluidRegistry.getFluid((platinumOre.toLowerCase())), platinumOre);
+            Fluid fluid = FluidRegistry.getFluid((platinumOre.toLowerCase()));
+            platinum.registerInitFluid(fluid, platinumOre);
+            this.registerDefaultMelting(platinumOre, fluid, true);
             platinum.setCraftable(false).setCastable(true);
         }
     }


### PR DESCRIPTION
# Description
Fixed not being able to melt and cast ingots/blocks of Thermal Foundation metals.

Fixes #8 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Built via the provided Gradle script w/ OpenJDK8
Ran PO3-3.3.57 locally, swapped out the Tinkers-Reforged mod using MultiMC.

Was able to melt blocks/ingots of various Thermal Foundations metals, and cast ingots/blocks into ingot casts and casting basins respectively.

I am by no means a professional, nor am I at all experienced with Minecraft modding. There is no guarantee this fix is the best fix, or that it doesn't break functionality elsewhere. Just trying to help.